### PR TITLE
fix: Add scsihw to cloud-init resource

### DIFF
--- a/.github/workflows/terraform-test.yaml
+++ b/.github/workflows/terraform-test.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   terraform:
     name: Test Terraform Module
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ resource "proxmox_vm_qemu" "virtual_machine_cloud_init" {
   tablet           = each.value.tablet
   boot             = each.value.boot
   bootdisk         = each.value.bootdisk
+  scsihw           = each.value.scsihw
   agent            = each.value.agent
   memory           = each.value.memory
   sockets          = each.value.cpu_sockets


### PR DESCRIPTION
### Pull Request Checklist

* [x] README.md updated
* [x] Lefthook installed and ran on commits

### PR Purpose

* fix: Add missing `scsihw` parameter to cloud-init resource
